### PR TITLE
Align gen_sphere with y-axis

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -235,30 +235,40 @@ pub fn gen_sphere() -> Vec<Vertex> {
 pub fn gen_sphere_segments(segs: f32, rings: f32) -> Vec<Vertex> {
     let mut vertices = Vec::new();
 
+    // handle the first ring, and maybe also the last
+
     for m in 0 .. rings as i32 {
         for n in 0 .. segs as i32 {
-            let n_plus = n + 1;
-            let m_plus = m + 1;
-            let verts = vec!(
-                [(PI * m as f32/rings).sin() * (PI2 * n as f32/segs).cos(),
-                (PI * m as f32/rings).sin() * (PI2 * n as f32/segs).sin(),
-                (PI * m as f32/rings).cos()],
-                [(PI * m_plus as f32/rings).sin() * (PI2 * n as f32/segs).cos(),
-                (PI * m_plus as f32/rings).sin() * (PI2 * n as f32/segs).sin(),
-                (PI * m_plus as f32/rings).cos()],
-                [(PI * m as f32/rings).sin() * (PI2 * n_plus as f32/segs).cos(),
-                (PI * m as f32/rings).sin() * (PI2 * n_plus as f32/segs).sin(),
-                (PI * m as f32/rings).cos()],
+            let r = m as f32;
+            let s = n as f32;
+            let r_plus = r + 1.0;
+            let s_plus = s + 1.0;
 
-                [(PI * m as f32/rings).sin() * (PI2 * n_plus as f32/segs).cos(),
-                (PI * m as f32/rings).sin() * (PI2 * n_plus as f32/segs).sin(),
-                (PI * m as f32/rings).cos()],
-                [(PI * m_plus as f32/rings).sin() * (PI2 * n as f32/segs).cos(),
-                (PI * m_plus as f32/rings).sin() * (PI2 * n as f32/segs).sin(),
-                (PI * m_plus as f32/rings).cos()],
-                [(PI * m_plus as f32/rings).sin() * (PI2 * n_plus as f32/segs).cos(),
-                (PI * m_plus as f32/rings).sin() * (PI2 * n_plus as f32/segs).sin(),
-                (PI * m_plus as f32/rings).cos()]);
+            let mut verts: Vec<[f32;3]> = Vec::new();
+
+            if r > 0.0 {
+                verts.push([(PI * r/rings).sin() * (PI2 * s_plus/segs).cos(),
+                    (PI * r/rings).cos(),
+                    (PI * r/rings).sin() * (PI2 * s_plus/segs).sin()]);
+                verts.push([(PI * r_plus/rings).sin() * (PI2 * s/segs).cos(),
+                    (PI * r_plus/rings).cos(),
+                    (PI * r_plus/rings).sin() * (PI2 * s/segs).sin()]);
+                verts.push([(PI * r/rings).sin() * (PI2 * s/segs).cos(),
+                    (PI * r/rings).cos(),
+                    (PI * r/rings).sin() * (PI2 * s/segs).sin()]);
+            }
+
+            if r < rings - 1.0 {
+                verts.push([(PI * r_plus/rings).sin() * (PI2 * s_plus/segs).cos(),
+                    (PI * r_plus/rings).cos(),
+                    (PI * r_plus/rings).sin() * (PI2 * s_plus/segs).sin()]);
+                verts.push([(PI * r_plus/rings).sin() * (PI2 * s/segs).cos(),
+                    (PI * r_plus/rings).cos(),
+                    (PI * r_plus/rings).sin() * (PI2 * s/segs).sin()]);
+                verts.push([(PI * r/rings).sin() * (PI2 * s_plus/segs).cos(),
+                    (PI * r/rings).cos(),
+                    (PI * r/rings).sin() * (PI2 * s_plus/segs).sin()]);
+            }
 
             let normal = calc_normal(verts[0], verts[1], verts[2]);
 

--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -233,9 +233,9 @@ pub fn gen_sphere() -> Vec<Vertex> {
 
 /// Generates a sphere mesh with segments and rings specified
 pub fn gen_sphere_segments(segs: f32, rings: f32) -> Vec<Vertex> {
-    let mut vertices = Vec::new();
+    assert!(segs > 1.0 && rings > 1.0, "segs and rings needs to be greater than 1");
 
-    // handle the first ring, and maybe also the last
+    let mut vertices = Vec::new();
 
     for m in 0 .. rings as i32 {
         for n in 0 .. segs as i32 {
@@ -246,6 +246,7 @@ pub fn gen_sphere_segments(segs: f32, rings: f32) -> Vec<Vertex> {
 
             let mut verts: Vec<[f32;3]> = Vec::new();
 
+            // skip first triangle on first ring
             if r > 0.0 {
                 verts.push([(PI * r/rings).sin() * (PI2 * s_plus/segs).cos(),
                     (PI * r/rings).cos(),
@@ -258,6 +259,7 @@ pub fn gen_sphere_segments(segs: f32, rings: f32) -> Vec<Vertex> {
                     (PI * r/rings).sin() * (PI2 * s/segs).sin()]);
             }
 
+            // skip last triangle on last ring
             if r < rings - 1.0 {
                 verts.push([(PI * r_plus/rings).sin() * (PI2 * s_plus/segs).cos(),
                     (PI * r_plus/rings).cos(),


### PR DESCRIPTION
This should align the generated sphere with the y-axis, so it's north and south pole points up and down.

The [if statements](https://github.com/shockham/caper/compare/master...Eibx:master#diff-e07d72a211226e6df239502943d1bb06R250) are there because the first and last ring should only be made up of triangles and not faces. I'm not sure if pushing to a `Vec` is the best way to do this. If you have any ideas I'm more than happy to do it differently.

If you need an example of the spheres, I can add that as well.

And as before, if you want anything changed I'm of course happy to change stuff. :)