### PR TITLE
make util::demo exit when escape key is pressed

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -368,8 +368,6 @@ pub fn demo(frag_shader: &'static str) {
                 UpdateStatus::Continue
             },
             events,
-        );
-
-        UpdateStatus::Continue
+        )
     });
 }


### PR DESCRIPTION
util::demo is supposed to exit when the escape key is pressed, but it does not.

To replicate the issue run `cargo run --example demo`, then try hitting escape.

The included change fixes the problem.